### PR TITLE
Fixed "Error | {'code': -32602, 'message': 'invalid argument 0:...

### DIFF
--- a/modules/nitro.py
+++ b/modules/nitro.py
@@ -85,7 +85,7 @@ class Nitro(Account):
             {
                 "from": self.w3.to_checksum_address(transaction_data["txn"]["from"]),
                 "to": self.w3.to_checksum_address(transaction_data["txn"]["to"]),
-                "value": transaction_data["txn"]["value"],
+                "value": int(transaction_data["txn"]["value"], 16),
                 "data": transaction_data["txn"]["data"],
             }
         )


### PR DESCRIPTION
Fixed "Error | {'code': -32602, 'message': 'invalid argument 0: json: cannot unmarshal hex number with leading zero digits into Go struct field TransactionArgs.value of type *hexutil.Big'}"